### PR TITLE
fix: target the targeted user for meme

### DIFF
--- a/src/generated/data/memes.json
+++ b/src/generated/data/memes.json
@@ -1,108 +1,189 @@
 [
-	{
-		"name": "Drake Hotline Bling",
-		"url": "https://imgflip.com/s/meme/Drake-Hotline-Bling.jpg",
-		"avatars": {
-			"author": [
-				{
-					"x": 53,
-					"y": 56,
-					"size": 97,
-					"style": "circle",
-					"rotation": -30
-				},
-				{
-					"x": 124,
-					"y": 244,
-					"size": 75,
-					"style": "circle",
-					"rotation": 8
-				}
-			],
-			"target": []
-		},
-		"boxes": [
-			{
-				"x": 300,
-				"y": 100,
-				"width": 190,
-				"height": 190,
-				"rotation": 0,
-				"textColor": "#ffffff",
-				"modifiers": {
-					"font": "impact",
-					"fontSize": 32,
-					"allCaps": false,
-					"bold": false,
-					"italic": false,
-					"outlineType": "outline",
-					"outlineWidth": 4,
-					"outlineColor": "#000000",
-					"textAlign": "center",
-					"verticalAlign": "middle",
-					"opacity": 1
-				}
-			},
-			{
-				"x": 300,
-				"y": 300,
-				"width": 190,
-				"height": 190,
-				"rotation": 0,
-				"textColor": "#ffffff",
-				"modifiers": {
-					"font": "impact",
-					"fontSize": 32,
-					"allCaps": false,
-					"bold": false,
-					"italic": false,
-					"outlineType": "outline",
-					"outlineWidth": 4,
-					"outlineColor": "#000000",
-					"textAlign": "center",
-					"verticalAlign": "middle",
-					"opacity": 1
-				}
-			}
-		]
-	},
-	{
-		"name": "Change my mind",
-		"url": "https://imgflip.com/s/meme/Change-My-Mind.jpg",
-		"avatars": {
-			"author": [
-				{
-					"x": 164,
-					"y": 55,
-					"size": 47,
-					"style": "circle",
-					"rotation": -13
-				}
-			],
-			"target": []
-		},
-		"boxes": [
-			{
-				"x": 261,
-				"y": 216,
-				"width": 163,
-				"height": 72,
-				"rotation": -7,
-				"textColor": "#000000",
-				"modifiers": {
-					"font": "arial",
-					"fontSize": 32,
-					"allCaps": false,
-					"bold": false,
-					"italic": false,
-					"outlineType": "none",
-					"outlineWidth": 4,
-					"outlineColor": "#000000",
-					"textAlign": "center",
-					"verticalAlign": "middle",
-					"opacity": 1
-				}
-			}
-		]
-	}
+  {
+    "name": "Drake Hotline Bling",
+    "url": "https://imgflip.com/s/meme/Drake-Hotline-Bling.jpg",
+    "avatars": {
+      "author": [],
+      "target": [
+        {
+          "x": 53,
+          "y": 56,
+          "size": 97,
+          "style": "circle",
+          "rotation": -30
+        },
+        {
+          "x": 124,
+          "y": 244,
+          "size": 75,
+          "style": "circle",
+          "rotation": 8
+        }
+      ]
+    },
+    "boxes": [
+      {
+        "x": 300,
+        "y": 100,
+        "width": 190,
+        "height": 190,
+        "rotation": 0,
+        "textColor": "#ffffff",
+        "modifiers": {
+          "font": "impact",
+          "fontSize": 32,
+          "allCaps": false,
+          "bold": false,
+          "italic": false,
+          "outlineType": "outline",
+          "outlineWidth": 4,
+          "outlineColor": "#000000",
+          "textAlign": "center",
+          "verticalAlign": "middle",
+          "opacity": 1
+        }
+      },
+      {
+        "x": 300,
+        "y": 300,
+        "width": 190,
+        "height": 190,
+        "rotation": 0,
+        "textColor": "#ffffff",
+        "modifiers": {
+          "font": "impact",
+          "fontSize": 32,
+          "allCaps": false,
+          "bold": false,
+          "italic": false,
+          "outlineType": "outline",
+          "outlineWidth": 4,
+          "outlineColor": "#000000",
+          "textAlign": "center",
+          "verticalAlign": "middle",
+          "opacity": 1
+        }
+      }
+    ]
+  },
+  {
+    "name": "Change my mind",
+    "url": "https://imgflip.com/s/meme/Change-My-Mind.jpg",
+    "avatars": {
+      "author": [],
+      "target": [
+        {
+          "x": 164,
+          "y": 55,
+          "size": 47,
+          "style": "circle",
+          "rotation": -13
+        }
+      ]
+    },
+    "boxes": [
+      {
+        "x": 261,
+        "y": 216,
+        "width": 163,
+        "height": 72,
+        "rotation": -7,
+        "textColor": "#000000",
+        "modifiers": {
+          "font": "arial",
+          "fontSize": 32,
+          "allCaps": false,
+          "bold": false,
+          "italic": false,
+          "outlineType": "none",
+          "outlineWidth": 4,
+          "outlineColor": "#000000",
+          "textAlign": "center",
+          "verticalAlign": "middle",
+          "opacity": 1
+        }
+      }
+    ]
+  },
+  {
+    "name": "Two Buttons",
+    "url": "https://imgflip.com/s/meme/Two-Buttons.jpg",
+    "avatars": {
+      "author": [],
+      "target": [
+        {
+          "x": 211,
+          "y": 408,
+          "size": 197,
+          "style": "circle",
+          "rotation": -8
+        }
+      ]
+    },
+    "boxes": [
+      {
+        "x": 106,
+        "y": 95,
+        "width": 117,
+        "height": 54,
+        "rotation": -14,
+        "textColor": "#000000",
+        "modifiers": {
+          "font": "arial",
+          "fontSize": 32,
+          "allCaps": false,
+          "bold": false,
+          "italic": false,
+          "outlineType": "none",
+          "outlineWidth": 4,
+          "outlineColor": "#000000",
+          "textAlign": "center",
+          "verticalAlign": "middle",
+          "opacity": 1
+        }
+      },
+      {
+        "x": 233,
+        "y": 69,
+        "width": 84,
+        "height": 45,
+        "rotation": -12,
+        "textColor": "#000000",
+        "modifiers": {
+          "font": "arial",
+          "fontSize": 32,
+          "allCaps": false,
+          "bold": false,
+          "italic": false,
+          "outlineType": "none",
+          "outlineWidth": 4,
+          "outlineColor": "#000000",
+          "textAlign": "center",
+          "verticalAlign": "middle",
+          "opacity": 1
+        }
+      },
+      {
+        "x": 200,
+        "y": 527,
+        "width": 364,
+        "height": 100,
+        "rotation": 0,
+        "textColor": "#ffffff",
+        "modifiers": {
+          "font": "impact",
+          "fontSize": 32,
+          "allCaps": false,
+          "bold": false,
+          "italic": false,
+          "outlineType": "shadow",
+          "outlineWidth": 4,
+          "outlineColor": "#000000",
+          "textAlign": "center",
+          "verticalAlign": "bottom",
+          "opacity": 1
+        }
+      }
+    ]
+  }
 ]


### PR DESCRIPTION
The `meme` command would have the `target` option for targeting users but it would only ping the user and never actually utilized that targeted user for the meme as the memes specifically targeted only the author, which doesn't make much sense for single-character memes that should be targeting the targeted user rather than the author whilst memes with 2 characters (of which none exist in the json and db as there's only 3 memes of which are all single-character memes) would make more sense to have the author being the main character and the targeted user being the secondary character.

- note: one change that can't be done here but would be necessary as well would be to swap the data between the `author` and `target` fields for all the memes in the db.